### PR TITLE
Parallelize calls to Mastodon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,21 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.2.1",
+        "bluebird": "^3.7.2",
         "date-fns": "^2.29.3",
         "form-data": "^4.0.0"
       },
       "devDependencies": {
+        "@types/bluebird": "^3.5.38",
         "@types/node": "^18.11.18",
         "typescript": "^4.9.4"
       }
+    },
+    "node_modules/@types/bluebird": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.38.tgz",
+      "integrity": "sha512-yR/Kxc0dd4FfwtEoLZMoqJbM/VE/W7hXn/MIjb+axcwag0iFmSPK7OBUZq1YWLynJUoWQkfUrI7T0HDqGApNSg==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "18.11.18",
@@ -38,6 +46,11 @@
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -141,6 +154,12 @@
     }
   },
   "dependencies": {
+    "@types/bluebird": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.38.tgz",
+      "integrity": "sha512-yR/Kxc0dd4FfwtEoLZMoqJbM/VE/W7hXn/MIjb+axcwag0iFmSPK7OBUZq1YWLynJUoWQkfUrI7T0HDqGApNSg==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
@@ -161,6 +180,11 @@
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "combined-stream": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^1.2.1",
+    "bluebird": "^3.7.2",
     "date-fns": "^2.29.3",
     "form-data": "^4.0.0"
   },
   "devDependencies": {
+    "@types/bluebird": "^3.5.38",
     "@types/node": "^18.11.18",
     "typescript": "^4.9.4"
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,14 @@
 import { formatIncidentMessage, getActiveIncidents } from './dallasPDData';
 import { publishStatus } from './mastodonApiClient';
+import bluebird from 'bluebird';
 
 // TODO: Use a library like `envalid` for environment variable type safety, instead of casting to string
 
 export const main = async () => {
     const incidents = await getActiveIncidents(process.env.DALLAS_ALERTS_OPENDATA_TOKEN as string);
     let numPublished = 0;
-    for (let incident of incidents) {
+
+    await bluebird.map(incidents, async (incident) => {
         const message = formatIncidentMessage(incident);
         try {
             await publishStatus(process.env.DALLAS_ALERTS_MASTODON_TOKEN as string, message, incident.incident_number);
@@ -16,7 +18,8 @@ export const main = async () => {
         } catch (e) {
             console.error(`Failed to publish incident ${incident.incident_number}`);
         }
-    }
+    }, { concurrency: 5 })
+
     return {
         totalIncidents: incidents.length,
         numPublished


### PR DESCRIPTION
Anecdotally:
- Parallelizing all calls in one big `Promise.all` resulted in a lot of 429s.
- 5 resulted in no 429s.
- 10 resulted in some 429s.

Runtime also seemed to have been reduced from 10s to 5s, but need to more thoroughly test that.

Also need to consider the added size and complexity of introducing bluebird. 